### PR TITLE
Compare ACF field date against current time

### DIFF
--- a/templates/blocks/events.php
+++ b/templates/blocks/events.php
@@ -38,7 +38,17 @@ function events($layout, $i) {
   );
   switch ($display) {
     case 'upcoming': break;
-    case 'past': $args['meta_compare'] = '<='; break;
+    case 'past':
+      $args['meta_query'] =
+        array(
+          'date_clause' => array(
+              'key' => 'date',
+              'compare' => '<=',
+              'value' => $today,
+              'type' => 'DATETIME',
+          ),
+        );
+      break;
     case 'category':
       $args['tax_query'] = array(
         'relation' => 'OR',
@@ -46,7 +56,8 @@ function events($layout, $i) {
 					'taxonomy' => 'event_categories',
 					'field'    => 'term_id',
 					'terms'    => $category,
-				));
+        ),
+      );
       break;
   }
   echo '<section class="event_block white">';

--- a/templates/taxonomies/event_categories.php
+++ b/templates/taxonomies/event_categories.php
@@ -1,6 +1,6 @@
 <?php
 date_default_timezone_set('America/Chicago');
-$today      = date('Ymd');
+$today      = date('YmdHis');
 $term = get_queried_object();
 $args = array(
 	'post_type' => 'events',
@@ -27,8 +27,12 @@ echo '<section class="event_block white">';
 		echo '<div class="full">';
 			$query = new WP_Query($args);
 			while ($query->have_posts()) {
+
 				$query->the_post();
-				event_preview();
+				
+				if( get_field('date',get_the_id())>$today){
+					event_preview();
+				}
 			}
 			wp_reset_query();
 		echo '</div>';

--- a/templates/taxonomies/event_types.php
+++ b/templates/taxonomies/event_types.php
@@ -1,7 +1,7 @@
 <?php
 date_default_timezone_set('America/Chicago');
-$today      = date('Ymd');
 
+$today = date('YmdHis');
 $term = get_queried_object();
 
 $args = array(
@@ -10,9 +10,6 @@ $args = array(
 	'posts_per_page' => -1,
 	'order' => 'ASC',
 	'orderby' => 'meta_value_num',
-	'meta_key' => 'date',
-	'meta_value' => $today,
-	'meta_compare' => '>='
 );
 $args = array(
 	'tax_query' => array(
@@ -30,7 +27,9 @@ echo '<section class="event_block white">';
 			$query = new WP_Query($args);
 			while ($query->have_posts()) {
 				$query->the_post();
-				event_preview();
+				if( get_field('date',get_the_id())>$today){
+					event_preview();
+				}
 			}
 			wp_reset_query();
 		echo '</div>';


### PR DESCRIPTION
Fixes past events, category, and taxonomy filtering bugs. 

Categories and Event Type categories were not being displayed on their archive pages, and past events were not being filtered correctly.

Comparing the date stored in the database for an ACF field against the current time can produce  undesirable results, because the database saves the time stamp in a different format.

This PR compares the current date with the ACF field format to ensure the date strings being compared are the same.