### PR TITLE
Add conference title and year between event lists

### DIFF
--- a/functions/wordpress/posts.php
+++ b/functions/wordpress/posts.php
@@ -39,7 +39,8 @@ function create_taxonomies() {
 		'people',
 		array(
 			'label' => __( 'Categories' ),
-			'hierarchical' => true,
+      'hierarchical' => true,
+      'show_admin_column' => true,
 		)
 	);
   register_taxonomy(
@@ -47,7 +48,8 @@ function create_taxonomies() {
 		'events',
 		array(
 			'label' => __( 'Categories' ),
-			'hierarchical' => true,
+      'hierarchical' => true,
+      'show_admin_column' => true,
 		)
   );
 }

--- a/scss/base/_typography.scss
+++ b/scss/base/_typography.scss
@@ -257,3 +257,10 @@ blockquote {
 
 h2 + h4 { margin: -($headline_margin/2) 0px $headline_margin 0px;  }
 p + h4 + p { margin-top: -$headline_margin;  }
+
+// event preview title
+
+h2.events-title {
+  margin-bottom: $pad*1;
+  margin-top: $pad*4;
+}

--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -98,6 +98,9 @@ section.image_grid {
 			@include break(1150px) { height: ($pad*50);	}
 		}
 	}
+	.image_description h4 {
+		text-align: center;
+	}
 }
 
 /* IMAGE PULL

--- a/templates/blocks/events.php
+++ b/templates/blocks/events.php
@@ -65,9 +65,36 @@ function events($layout, $i) {
     echo '<article>';
       echo '<div class="full">';
         $query = new WP_Query($args);
+
+        // Create new array called years
+        $years = array();
+
         while ($query->have_posts()) {
           $query->the_post();
-          event_preview();
+
+          // Get date format and ACF date field
+          $date  = DateTime::createFromFormat('YmdHis', get_field('date'));
+          // Format date to return only the year
+          $year  = $date->format('Y');
+           
+          // If year is not in array, then echo title          
+          if ( ! isset( $years[ $year ] ) ) {
+
+            /* For every year inside of years, create 
+            * another array before displaying title
+            */
+
+             $years[ $year ] = array();
+             
+             echo '<h2 class="events-title">'. $year . ' Conference</h2>';
+             
+          } 
+
+          /* Display events after year array
+          * otherwise title will display for every event
+          */
+           event_preview();
+
         }
         wp_reset_query();
       echo '</div>';

--- a/templates/blocks/image_grid.php
+++ b/templates/blocks/image_grid.php
@@ -22,8 +22,6 @@ function image_grid($layout, $i) {
             if($item['link']) { echo '<a class="image" href="'.$item['link'].'">';  }
             else { echo '<a class="image lightbox" target="_blank" href="'.$item['photo']['url'].'" data-caption="'.$item['headline'].' // '.$item['copy'].'">';  }
               echo '<img src="'.$item['photo']['sizes']['medium'].'" alt="'.$item['photo']['alt'].'" />';
-              if($item['link']) { echo '<i class="fas fa-angle-right"></i>'; } 
-              else { echo '<i class="fas fa-images"></i>'; }
 
               echo '<span class="sr">'.$item['headline'].'</span>';
             echo '</a>';


### PR DESCRIPTION
* Separate list of events with same year by conference title (example below)
* Center title under image grid block
* Remove hover icons from image grid block
* Show admin bar for custom post types within dashboard so editor can see associated categories

<img width="697" alt="screen shot 2018-04-30 at 1 11 09 pm" src="https://user-images.githubusercontent.com/12139428/39442796-0beb0c94-4c78-11e8-9ad8-c9e1fc994075.png">
