### PR TITLE
Increase width of hero headline

### DIFF
--- a/scss/layout/_header.scss
+++ b/scss/layout/_header.scss
@@ -72,7 +72,7 @@ header {
 		@extend .center;
 		position: relative;
 		z-index: 5;
-		max-width: $onecol;
+		max-width: 800px;
 		margin: 0 auto;
 	}
 	h1 {


### PR DESCRIPTION
Increase the max-width of the header container.

<img width="969" alt="screen shot 2018-05-06 at 10 10 46 am" src="https://user-images.githubusercontent.com/12139428/39674722-d625d20e-5115-11e8-8feb-1a80422e2340.png">
