### PR TITLE
Add button styles to regisration menu link

### DIFF
--- a/scss/modules/_menu.scss
+++ b/scss/modules/_menu.scss
@@ -227,6 +227,15 @@ nav.main {
  * styles.
  ***************************************************/
 @include desktop_menu {
+
+	body.scrolled nav.main ul.top_level {
+		li.register-button {
+			> a {
+				background-color: $secondary;
+				color: $white !important; 
+			}
+		} 
+	}
 	nav.mobile {
 		display: none;
 	}
@@ -261,7 +270,7 @@ nav.main {
 	nav.main {
 		padding: 0px;
 		width: 100%;
-		z-index: 99;
+		z-index: 999;
 		right: auto;
 		top: auto;
 		bottom: auto;
@@ -282,7 +291,20 @@ nav.main {
 				display: inline-block;
 				border-bottom: 0px;
 				position: relative;
+
 				&:hover a { background: none; }
+
+				&.register-button {
+					margin-top: 8px;
+
+					> a {
+						padding-top: 2px;
+						padding-bottom: 2px;
+						color: $primary !important;
+						background-color: $white;
+					}
+				}
+
 				> a {
 					display: inline-block;
 					&:after { display: none;  }


### PR DESCRIPTION
When user adds class `register-button` to a man menu link, this PR adds the appropriate button styling. 

* Registration button on desktop: 
<img width="1368" alt="screen shot 2018-06-03 at 1 28 58 pm" src="https://user-images.githubusercontent.com/12139428/40889814-8909ef36-6732-11e8-8c90-b0a368e15fbd.png">

* Make register button on desktop when user scrolls: 
<img width="1023" alt="screen shot 2018-06-03 at 1 28 50 pm" src="https://user-images.githubusercontent.com/12139428/40889818-a010d384-6732-11e8-86aa-77674a88421b.png">

