### PR TITLE
Increase social icon size

### DIFF
--- a/scss/layout/_singles.scss
+++ b/scss/layout/_singles.scss
@@ -103,7 +103,18 @@ section.single_event  {
 		.media {
 			padding: 0px;
 			margin: 0px;
-			li { margin: 0px; padding: 1px; }
+			li { 
+				
+				margin: 0px; padding: 1px; 
+			
+				a {
+					width: 48px;
+					 svg {
+						font-size: 32px;
+					}
+				}
+			
+			}
 		}
 	}
 	.event_details {


### PR DESCRIPTION
Increase the size of social media icons under contact blocks

<img width="868" alt="screen shot 2018-07-18 at 6 12 57 pm" src="https://user-images.githubusercontent.com/12139428/42912700-604f8068-8ab6-11e8-85f7-b5c21dc833b9.png">
